### PR TITLE
Webhook ENV var not being set properly

### DIFF
--- a/modules/password-rotation/README.md
+++ b/modules/password-rotation/README.md
@@ -110,8 +110,8 @@ For more detailed usage and troubleshooting, please refer to the function code a
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_password_lambda"></a> [password\_lambda](#module\_password\_lambda) | git::<https://github.com/terraform-aws-modules/terraform-aws-lambda.git> | v7.2.6 |
-| <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | git::<https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git> | v1.1.2 |
+| <a name="module_password_lambda"></a> [password\_lambda](#module\_password\_lambda) | git::https://github.com/terraform-aws-modules/terraform-aws-lambda.git | v7.2.6 |
+| <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | git::https://github.com/terraform-aws-modules/terraform-aws-secrets-manager.git | v1.1.2 |
 
 ## Resources
 

--- a/modules/password-rotation/main.tf
+++ b/modules/password-rotation/main.tf
@@ -26,11 +26,11 @@ module "password_lambda" {
   }
 
   environment_variables = {
-    USERS                    = join(",", var.users) # takes a list of users and joins them into a comma separated string
-    ROTATION_TAG_KEY         = var.rotation_tag_key
-    ROTATION_TAG_VALUE       = var.rotation_tag_value
-    NOTIFICATION_WEBHOOK_URL = var.notification_webhook_url
-    WEBHOOK_SECRET_ID        = var.notification_webhook_secret_id
+    USERS              = join(",", var.users) # takes a list of users and joins them into a comma separated string
+    ROTATION_TAG_KEY   = var.rotation_tag_key
+    ROTATION_TAG_VALUE = var.rotation_tag_value
+    WEBHOOK_URL        = var.notification_webhook_url
+    WEBHOOK_SECRET_ID  = var.notification_webhook_secret_id
   }
 
   assume_role_policy_statements = {


### PR DESCRIPTION
In Terraform we passed in the following ENV var `NOTIFICATION_WEBHOOK_URL = var.notification_webhook_url` and in python its looking for `webhook_url = os.environ.get("WEBHOOK_URL")` This meant passing in `var.notifaction_webhook_url` didn't actually work. 

Fixed by adjusted the tf to pass the var  `WEBHOOK_URL` to lambda